### PR TITLE
Fix bug where `has_exe()` reports false due to too much data reported by 'which' or 'where'

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -21,6 +21,7 @@
 #include <QFileInfo>
 #include <QPalette>
 #include <QProcess>
+#include <QRegularExpression>
 #include <QStringList>
 #include <QWidget>
 
@@ -194,9 +195,12 @@ bool has_exe(const QString &exe)
     if (!findProcess.waitForFinished()) return false; // Not found or which does not work
 
     QString retStr(findProcess.readAll());
-    retStr = retStr.trimmed();
 
-    QFile file(retStr);
+    // truncate multi-line output to first line
+    auto idx = retStr.indexOf(QRegularExpression("[\n\r]"), 0);
+    if (idx > 0) retStr.truncate(idx);
+
+    QFile file(retStr.trimmed());
     QFileInfo check_file(file);
     return (check_file.exists() && check_file.isFile());
 }


### PR DESCRIPTION
**Summary**

We need to truncate the output of the 'which' or 'where' commands at the first newline so that multi-line output will not result in an incorrect result of the `has_exec()` function.

**Related Issue(s)**

Fixes #7 

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS-GUI and redistributed under the GNU General Public License version 2 (GPL v2).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
