### PR TITLE
we can only guess elements from masses when using per-type masses

### DIFF
--- a/src/imageviewer.cpp
+++ b/src/imageviewer.cpp
@@ -868,7 +868,7 @@ void ImageViewer::createImage()
     QString elements = "element ";
     QString adiams;
     useelements = false;
-    if ((units == "real") || (units == "metal")) {
+    if (masses && (units == "real") || (units == "metal")) {
         useelements = true;
         for (int i = 1; i <= ntypes; ++i) {
             int idx = get_pte_from_mass(masses[i]);


### PR DESCRIPTION
**Summary**

Avoid segfault when launching the ImageViewer window for systems with per-atom masses.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS-GUI and redistributed under the GNU General Public License version 2 (GPL v2).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
