### PR TITLE
Windows packaging fixes for Qt6

### DIFF
--- a/packaging/build_windows_cross_nsis.sh
+++ b/packaging/build_windows_cross_nsis.sh
@@ -25,7 +25,7 @@ wget https://download.lammps.org/thirdparty/gzip.exe.gz
 gunzip gzip.exe.gz
 mv gzip.exe ${DESTDIR}/bin/
 
-skipdlls="msvcrt ADVAPI32 CFGMGR32 GDI32 KERNEL32 MPR NETAPI32 PSAPI SHELL32 USER32 USERENV UxTheme VERSION WS2_32 WSOCK32 d3d11 dwmapi liblammps msvcrt_ole32 dxgi IMM32 ole32 OLEAUT32 WINMM WTSAPI32 COMCTL32 PSAPI bcrypt CRYPT32 IPHLPAPI Secur32 api-ms-win-core-path-l1-1-0 WLDAP32"
+skipdlls="msvcrt ADVAPI32 CFGMGR32 GDI32 KERNEL32 MPR NETAPI32 PSAPI SHELL32 USER32 USERENV UxTheme VERSION WS2_32 WSOCK32 d3d11 dwmapi liblammps msvcrt_ole32 dxgi IMM32 ole32 OLEAUT32 WINMM WTSAPI32 COMCTL32 PSAPI bcrypt CRYPT32 IPHLPAPI Secur32 api-ms-win-core-path-l1-1-0 WLDAP32 api-ms-win-core-synch-l1-2-0 AUTHZ d3d12 DWrite ntdll api-ms-win-core-winrt-l1-1-0 api-ms-win-core-winrt-string-l1-1-0 comdlg32 d2d1 d3d9 SETUPAPI SHCORE SHLWAPI"
 echo "Copying required DLL files"
 for dll in $(objdump -p *.exe | sed -n -e '/DLL Name:/s/^.*DLL Name: *//p' | sort | uniq)
 do \
@@ -33,39 +33,39 @@ do \
     for skip in ${skipdlls}
     do \
         test ${dll} = ${skip}.dll && doskip=1
-        test ${dll} = ${skip}.DLL && doskip=1        
+        test ${dll} = ${skip}.DLL && doskip=1
     done
     test ${doskip} -eq 1 && continue
     test -f ${DESTDIR}/bin/${dll} || cp -v ${SYSROOT}/bin/${dll} ${DESTDIR}/bin || exit 1
 done
 
 echo "Copy required Qt plugins"
-mkdir -p ${DESTDIR}/qt5plugins
+mkdir -p ${DESTDIR}/qt6plugins
 for plugin in imageformats platforms styles
 do \
-    cp -r ${SYSROOT}/lib/qt5/plugins/${plugin} ${DESTDIR}/qt5plugins/
+    cp -r ${SYSROOT}/lib/qt6/plugins/${plugin} ${DESTDIR}/qt6plugins/
 done
 
 echo "Check dependencies of DLL files"
-for dll in $(objdump -p ${DESTDIR}/bin/*.dll ${DESTDIR}/qt5plugins/*/*.dll | sed -n -e '/DLL Name:/s/^.*DLL Name: *//p' | sort | uniq)
+for dll in $(objdump -p ${DESTDIR}/bin/*.dll ${DESTDIR}/qt6plugins/*/*.dll | sed -n -e '/DLL Name:/s/^.*DLL Name: *//p' | sort | uniq)
 do \
     doskip=0
     for skip in ${skipdlls}
     do \
         test ${dll} = ${skip}.dll && doskip=1
-        test ${dll} = ${skip}.DLL && doskip=1        
+        test ${dll} = ${skip}.DLL && doskip=1
     done
     test ${doskip} -eq 1 && continue
     test -f ${DESTDIR}/bin/${dll} || cp -v ${SYSROOT}/bin/${dll} ${DESTDIR}/bin || exit 1
 done
 
-for dll in $(objdump -p ${DESTDIR}/bin/*.dll ${DESTDIR}/qt5plugins/*/*.dll | sed -n -e '/DLL Name:/s/^.*DLL Name: *//p' | sort | uniq)
+for dll in $(objdump -p ${DESTDIR}/bin/*.dll ${DESTDIR}/qt6plugins/*/*.dll | sed -n -e '/DLL Name:/s/^.*DLL Name: *//p' | sort | uniq)
 do \
     doskip=0
     for skip in ${skipdlls}
     do \
         test ${dll} = ${skip}.dll && doskip=1
-        test ${dll} = ${skip}.DLL && doskip=1        
+        test ${dll} = ${skip}.DLL && doskip=1
     done
     test ${doskip} -eq 1 && continue
     test -f ${DESTDIR}/bin/${dll} || cp -v ${SYSROOT}/bin/${dll} ${DESTDIR}/bin || exit 1
@@ -73,7 +73,7 @@ done
 
 cat > ${DESTDIR}/bin/qt.conf <<EOF
 [Paths]
-Plugins = ../qt5plugins
+Plugins = ../qt6plugins
 EOF
 
 cp -v lammps-gui-v${VERSION}.pdf ${DESTDIR}/LAMMPS-GUI-Manual.pdf

--- a/packaging/lammps-gui.nsis
+++ b/packaging/lammps-gui.nsis
@@ -129,15 +129,16 @@ Section "${LAMMPSGUI}" SecLammps
   File bin/*.dll
   File bin/qt.conf
 
-  # install Qt5 plugins
-  SetOutPath "$INSTDIR\qt5plugins\platforms"
-  File ${MINGW}/../lib/qt5/plugins/platforms/qwindows.dll
-  SetOutPath "$INSTDIR\qt5plugins\imageformats"
-  File ${MINGW}/../lib/qt5/plugins/imageformats/qgif.dll
-  File ${MINGW}/../lib/qt5/plugins/imageformats/qico.dll
-  File ${MINGW}/../lib/qt5/plugins/imageformats/qjpeg.dll
-  SetOutPath "$INSTDIR\qt5plugins\styles"
-  File ${MINGW}/../lib/qt5/plugins/styles/qwindowsvistastyle.dll
+  # install Qt6 plugins
+  SetOutPath "$INSTDIR\qt6plugins\platforms"
+  File ${MINGW}/../lib/qt6/plugins/platforms/qwindows.dll
+  File ${MINGW}/../lib/qt6/plugins/platforms/qdirect2d.dll
+  SetOutPath "$INSTDIR\qt6plugins\imageformats"
+  File ${MINGW}/../lib/qt6/plugins/imageformats/qgif.dll
+  File ${MINGW}/../lib/qt6/plugins/imageformats/qico.dll
+  File ${MINGW}/../lib/qt6/plugins/imageformats/qjpeg.dll
+  SetOutPath "$INSTDIR\qt6plugins\styles"
+  File ${MINGW}/../lib/qt6/plugins/styles/qmodernwindowsstyle.dll
 
   SetOutPath "$INSTDIR\Doc"
   File *.pdf
@@ -203,7 +204,7 @@ Section "Uninstall"
   Delete /REBOOTOK   "$INSTDIR\Uninstall.exe"
   RMDir /r /REBOOTOK "$INSTDIR\bin"
   RMDir /r /REBOOTOK "$INSTDIR\Doc"
-  RMDir /r /REBOOTOK "$INSTDIR\qt5plugins"
+  RMDir /r /REBOOTOK "$INSTDIR\qt6plugins"
   RMDir /REBOOTOK "$INSTDIR"
 SectionEnd
 


### PR DESCRIPTION
**Summary**

Linux-2-Windows cross-compilation now uses Qt6 and includes gzip.exe and ffmpeg.exe

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS-GUI and redistributed under the GNU General Public License version 2 or later (GPL v2+).

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
