### PR TITLE
Create signed and pure GUI packages for Windows

### DIFF
--- a/.github/workflows/compile-mingw64-cross.yml
+++ b/.github/workflows/compile-mingw64-cross.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: fedora:latest
+    env:
+      SIGN_DISABLE: 1
 
     steps:
     - name: Install system dependencies
@@ -69,7 +71,8 @@ jobs:
       run: |
         mingw64-cmake -S . -B build \
               -D LAMMPS_GUI_USE_PLUGIN=yes \
-              -D BUILD_DOC=yes
+              -D BUILD_DOC=yes \
+              -D CODE_SIGNING=no
         cmake --build build --parallel 2
 
     - name: Build NSIS installer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 project(lammps-gui
   VERSION 3.0.5
   LANGUAGES CXX
-  DESCRIPTION "The LAMMPS GUI"
+  DESCRIPTION "The LAMMPS Graphical User Interface"
   HOMEPAGE_URL "https://lammps-gui.lammps.org/")
 
 include(GNUInstallDirs)
@@ -40,6 +40,8 @@ if (NOT BUILD_DOC_ONLY)
 
   # install prefix, compiler and platform quirks, plugin loader, bundle resources
   include(${CMAKE_SOURCE_DIR}/cmake/Platform.cmake)
+  # support for signing executables
+  include(${CMAKE_SOURCE_DIR}/cmake/Signing.cmake)
 
   # charts are rendered by the self-contained native QPainter backend; only the
   # LGPL Qt Widgets are needed (no Qt Charts / Graphs / Quick modules)
@@ -58,7 +60,7 @@ if (NOT BUILD_DOC_ONLY)
     ${PROJECT_SOURCES}
   )
 
-  # when compiling for macOS request compilation of an app-bundle
+  # when compiling for macOS, request compilation of an app-bundle
   if(APPLE)
     string(TIMESTAMP CURRENT_YEAR "%Y")
     set_target_properties(lammps-gui PROPERTIES
@@ -72,9 +74,16 @@ if (NOT BUILD_DOC_ONLY)
     # purge app bundle directory during configure
     file(REMOVE_RECURSE ${CMAKE_BINARY_DIR}/lammps-gui.app)
   endif()
+
+  # when compiling for Windows, call the WinMain entry point for a pure GUI application
+  if(WIN32)
+    set_target_properties(lammps-gui PROPERTIES WIN32_EXECUTABLE TRUE)
+  endif()
+
   install(TARGETS lammps-gui DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   qt_finalize_executable(lammps-gui)
+  sign_target(lammps-gui)
 
   # compilation settings
   if(LAMMPS_GUI_USE_PLUGIN)

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -34,10 +34,13 @@ if(LAMMPS_GUI_USE_PLUGIN)
   set(PLUGIN_LOADER_SRC ${LAMMPS_PLUGINLIB_DIR}/liblammpsplugin.c)
 endif()
 
-# include resource compiler to embed icons into the executable on Windows
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+# include resource compiler to embed icons and metadata into the executable on Windows
+if(WIN32)
   enable_language(RC)
-  set(ICON_RC_FILE ${CMAKE_SOURCE_DIR}/resources/lmpicons.rc)
+  configure_file(${CMAKE_SOURCE_DIR}/resources/lmpicons.rc ${CMAKE_BINARY_DIR}/lmpicons.rc)
+  file(COPY ${CMAKE_SOURCE_DIR}/resources/lammps-gui.ico  ${CMAKE_SOURCE_DIR}/resources/lmpfile.ico
+    DESTINATION ${CMAKE_BINARY_DIR})
+  set(ICON_RC_FILE ${CMAKE_BINARY_DIR}/lmpicons.rc)
 endif()
 
 # icon, readme, and installer resources for the macOS app bundle; prefer

--- a/cmake/Signing.cmake
+++ b/cmake/Signing.cmake
@@ -1,0 +1,41 @@
+# Signing.cmake - support for cryptographic signing of binaries
+#
+#   include(packaging/Signing.cmake)
+#   ...
+#   add_executable(myapp ...)
+#   sign_target(myapp)                 # signs the exe right after linking
+#
+# Signing only activates for Windows cross builds and can be switched off
+# with -DCODE_SIGNING=OFF (or SIGN_DISABLE=1 in the environment).
+
+if((CMAKE_SYSTEM_NAME STREQUAL "Windows") AND CMAKE_CROSSCOMPILING)
+  option(CODE_SIGNING "Authenticode-sign Windows binaries" ON)
+else()
+  option(CODE_SIGNING "Authenticode-sign Windows binaries" OFF)
+endif()  
+
+set(SIGN_SCRIPT "${CMAKE_SOURCE_DIR}/packaging/sign.sh")
+
+function(sign_target tgt)
+    if(NOT WIN32 OR NOT CODE_SIGNING)
+        return()
+    endif()
+    add_custom_command(TARGET ${tgt} POST_BUILD
+        COMMAND "${SIGN_SCRIPT}" "$<TARGET_FILE:${tgt}>"
+        COMMENT "Authenticode signing $<TARGET_FILE:${tgt}>"
+        VERBATIM)
+endfunction()
+
+# Optional helper for signing loose files (bundled DLLs etc.) as part of a
+# packaging target:
+#   sign_files(sign_deps "${CMAKE_BINARY_DIR}/dist/foo.dll" ...)
+function(sign_files custom_target_name)
+    if(NOT WIN32 OR NOT CODE_SIGNING)
+        add_custom_target(${custom_target_name})
+        return()
+    endif()
+    add_custom_target(${custom_target_name}
+        COMMAND "${SIGN_SCRIPT}" ${ARGN}
+        COMMENT "Authenticode signing bundled files"
+        VERBATIM)
+endfunction()

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -157,20 +157,63 @@ Windows 10 and later
    :align: right
    :width: 25%
 
-After downloading either the ``LAMMPS-Win10-64bit-GUI-<LAMMPS version>.exe``
-or the ``LAMMPS-GUI-Win10-x86_64-<LAMMPS-GUI version>.exe`` installer
-package, you need to execute it, and start the installation process.
-Depending on your security settings of your web browser, you may have to
-explicitly tell it to download the file and then confirm **twice** to
-*keep the downloaded file* despite the claims that it may be dangerous
-and insecure.  Since the installer packages are currently not
-cryptographically signed, you may also have to enable "Developer Mode"
-in the Windows System Settings to be able to run the installer.
-
 .. image:: JPG/windows-download-keep1.png
-   :align: center
-   :width: 33%
+   :align: right
+   :width: 25%
 
+After downloading either the ``LAMMPS-Win10-64bit-GUI-<LAMMPS
+version>.exe`` or the ``LAMMPS-GUI-Win10-x86_64-<LAMMPS-GUI
+version>.exe`` installer package, you need to execute it, and start the
+installation process.  Depending on your security settings of your web
+browser, you may have to explicitly tell it to download the file and
+then confirm **twice** to *keep the downloaded file* despite the claims
+that it may be dangerous and insecure.  The main reason for that is that
+one needs to pay for being a registered developer and obtain a
+corresponding cryptographic signature to sign the binaries with.
+
+.. admonition:: Managing Microsoft Defender SmartScreen protection
+   :class: hint
+
+   Since LAMMPS-GUI version 3.0.5 the Windows installer packages and the
+   included executables are cryptographically signed with a
+   *self-signed* certificate.  You now have two options:
+
+   **Option A: just ignore the warnings**
+
+   When the message "Windows protected your PC" appears, click *More info*,
+   and then *Run anyway*.  You may also have to enable "Developer Mode"
+   in the Windows System Settings to be able to run the installer.
+   Using a cryptographic signature still guarantees the file has not
+   been modified since we built it, so you have that extra protection.
+   This may be needed since these installer packages sometimes cause
+   false positives with anti-virus software and are reported as containing
+   a trojan
+
+   **Option B: install and trust our self-signed certificate**
+
+   You can download our self-signed public certificate from
+   https://download.lammps.org/lammps-gui/LAMMPS-GUI.cer (The SHA-256
+   hash of this file is
+   ``2a90ba8d0d3406fba6d67e6edb3f4904b1684756abf777bd2c58464ab1dff2cd``) and
+   then open a "Command Prompt" with **Administrator** permissions.  At
+   the prompt you run the following two commands to import and trust the
+   certificate.
+
+   ``certutil -addstore Root LAMMPS-GUI.cer``
+
+   ``certutil -addstore TrustedPublisher LAMMPS-GUI.cer``
+
+   **Security note:** Adding a certificate to the Root store means your
+   computer will trust *anything* signed with the matching private key.
+   Only install certificates from publishers you trust, obtained over
+   HTTPS from their official site.
+
+   If you ever wish to *remove* this certificate, you can do it with
+   with the following commands.
+
+   ``certutil -delstore Root "The LAMMPS Developers"``
+
+   ``certutil -delstore TrustedPublisher "The LAMMPS Developers"``
 
 MacOS 12 and later
 """"""""""""""""""

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -430,14 +430,14 @@ drag-n-drop installer, ``LAMMPS-GUI-macOS-multiarch-<version>.dmg``,
 when using the 'dmg' target (i.e. ``cmake --build <build dir> --target
 dmg`` or ``make dmg``).
 
-To build multi-arch executables that will run on both, arm64 and x86_64
-architectures natively, it is necessary to set the CMake variable ``-D
-CMAKE_OSX_ARCHITECTURES=arm64;x86_64``.  To achieve wide compatibility
-with different macOS versions, you can also set ``-D
+To build multi-arch executables on macOS that will run on both, arm64
+and x86_64 architectures natively, it is necessary to set the CMake
+variable ``-D CMAKE_OSX_ARCHITECTURES=arm64;x86_64``.  To achieve wide
+compatibility with different macOS versions, you can also set ``-D
 CMAKE_OSX_DEPLOYMENT_TARGET=12.0`` which will set compatibility to macOS
-12 (Monterey) and later, even if you are compiling on a more recent macOS
-version.  These are the settings used when building the pre-compiled
-LAMMPS-GUI packages.
+12 (Monterey) and later, even if you are compiling on a more recent
+macOS version.  These are the settings currently used when building the
+pre-compiled LAMMPS-GUI packages.
 
 Windows
 """""""
@@ -448,6 +448,12 @@ compilation with the MinGW / GCC cross-compiler environment on Fedora
 Linux.  All pre-compiled LAMMPS-GUI packages for Windows are created
 with the MinGW64 cross-compiler; the native Visual C++ compilation is a
 development configuration without deployment or packaging support.
+
+Since LAMMPS-GUI version 3.0.5, the build process includes generating
+cryptographically signed executables and installer packages.  This is
+enabled by default but can be turned off with ``-D CODE_SIGNING=no``
+during CMake configuration and setting the environment variable
+``SIGN_DISABLE`` to 1.
 
 *Visual Studio*
 

--- a/packaging/build_windows_cross_nsis.sh
+++ b/packaging/build_windows_cross_nsis.sh
@@ -21,9 +21,11 @@ mv -v liblammps.dll ${DESTDIR}/bin/
 wget https://download.lammps.org/thirdparty/ffmpeg-win64.exe.gz
 gunzip ffmpeg-win64.exe.gz
 mv ffmpeg-win64.exe ${DESTDIR}/bin/ffmpeg.exe
+${SRCDIR}/packaging/sign.sh ${DESTDIR}/bin/ffmpeg.exe
 wget https://download.lammps.org/thirdparty/gzip.exe.gz
 gunzip gzip.exe.gz
 mv gzip.exe ${DESTDIR}/bin/
+${SRCDIR}/packaging/sign.sh ${DESTDIR}/bin/gzip.exe
 
 skipdlls="msvcrt ADVAPI32 CFGMGR32 GDI32 KERNEL32 MPR NETAPI32 PSAPI SHELL32 USER32 USERENV UxTheme VERSION WS2_32 WSOCK32 d3d11 dwmapi liblammps msvcrt_ole32 dxgi IMM32 ole32 OLEAUT32 WINMM WTSAPI32 COMCTL32 PSAPI bcrypt CRYPT32 IPHLPAPI Secur32 api-ms-win-core-path-l1-1-0 WLDAP32 api-ms-win-core-synch-l1-2-0 AUTHZ d3d12 DWrite ntdll api-ms-win-core-winrt-l1-1-0 api-ms-win-core-winrt-string-l1-1-0 comdlg32 d2d1 d3d9 SETUPAPI SHCORE SHLWAPI DNSAPI WINHTTP ncrypt"
 echo "Copying required DLL files"
@@ -75,6 +77,11 @@ cat > ${DESTDIR}/bin/qt.conf <<EOF
 [Paths]
 Plugins = ../qt6plugins
 EOF
+
+for f in ${DESTDIR}/bin/*.dll
+do \
+    ${SRCDIR}/packaging/sign.sh $f
+done
 
 cp -v lammps-gui-v${VERSION}.pdf ${DESTDIR}/LAMMPS-GUI-Manual.pdf
 cp -v ${SRCDIR}/LICENSE ${DESTDIR}/LICENSE.txt

--- a/packaging/lammps-gui.nsis
+++ b/packaging/lammps-gui.nsis
@@ -16,6 +16,17 @@
 !define MUI_HEADERIMAGE_BITMAP "lammps-gui-banner.bmp"
 !define MUI_HEADERIMAGE_RIGHT
 
+# sign the installer and uninstaller
+# %1 is substituted by makensis with the path of the produced file.
+
+# Sign the finished installer itself
+!finalize       '"${__FILEDIR__}\..\..\packaging\sign.sh" "%1"' = 0
+
+# Sign the uninstaller stub. NSIS extracts the uninstaller, hands it to this
+# command, then embeds the signed copy back into the installer. Without this
+# your uninstall.exe stays unsigned and can trip Defender on its own.
+!uninstfinalize '"${__FILEDIR__}\..\..\packaging\sign.sh" "%1"' = 0
+
 Unicode true
 XPStyle on
 

--- a/packaging/sign.sh
+++ b/packaging/sign.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Sign a PE file (exe/dll/installer) in place with osslsigncode.
+# Usage: sign.sh <file> [more files...]
+#
+# Config via environment:
+#   SIGN_PFX       path to pfx        (default: ~/.codesign/codesign.pfx)
+#   SIGN_PASSWORD  pfx password      (required)
+#   SIGN_NAME      program name shown in the signature
+#   SIGN_URL       project URL shown in the signature
+#   SIGN_DISABLE   set to 1 to make this a no-op (unsigned dev builds)
+#
+# This script is the ONLY place that knows how signing happens. When you
+# later move to Azure Artifact Signing / a real OV cert, you change this
+# file and nothing else in the build.
+set -euo pipefail
+
+[[ "${SIGN_DISABLE:-0}" == "1" ]] && { echo "sign.sh: signing disabled"; exit 0; }
+
+SIGN_PFX="${SIGN_PFX:-$HOME/.codesign/lammps-gui.pfx}"
+SIGN_NAME="${SIGN_NAME:-LAMMPS-GUI}"
+SIGN_URL="${SIGN_URL:-https://lammps-gui.lammps.org}"
+TSA="http://timestamp.digicert.com"   # free RFC-3161 timestamp server
+
+if [[ -z "${SIGN_PASSWORD:-}" ]]; then
+    echo "sign.sh: SIGN_PASSWORD is not set" >&2
+    exit 1
+fi
+
+command -v osslsigncode >/dev/null || {
+    echo "sign.sh: osslsigncode not found (apt install osslsigncode)" >&2
+    exit 1
+}
+
+for f in "$@"; do
+    tmp="$(mktemp --tmpdir="$(dirname "$f")" "$(basename "$f").XXXX.signed")"
+    rm -f ${tmp}
+
+    # Timestamping works fine with self-signed certs; it means the
+    # signature stays valid after the cert expires.
+    osslsigncode sign \
+        -pkcs12 "$SIGN_PFX" -pass "$SIGN_PASSWORD" \
+        -n "$SIGN_NAME" -i "$SIGN_URL" \
+        -h sha256 -ts "$TSA" \
+        -in "$f" -out "$tmp"
+
+    mv -f "$tmp" "$f"
+    osslsigncode verify -in "$f" >/dev/null 2>&1 || true
+    echo "signed: $f"
+done

--- a/resources/lmpicons.rc
+++ b/resources/lmpicons.rc
@@ -1,2 +1,25 @@
-1 ICON "lammps-gui.ico"
-2 ICON "lmpfile.ico"
+1 VERSIONINFO
+FILEVERSION     1,0,0,0
+PRODUCTVERSION  1,0,0,0
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904E4"
+    BEGIN
+      VALUE "CompanyName", "The LAMMPS Developers"
+      VALUE "FileDescription", "@PROJECT_DESCRIPTION@"
+      VALUE "FileVersion", "1.0"
+      VALUE "InternalName", "lammps-gui"
+      VALUE "LegalCopyright", "Axel Kohlmeyer"
+      VALUE "OriginalFilename", "lammps-gui.exe"
+      VALUE "ProductName", "LAMMPS-GUI"
+      VALUE "ProductVersion", "@PROJECT_VERSION@"
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x409, 1252
+  END
+END
+2 ICON "lammps-gui.ico"
+3 ICON "lmpfile.ico"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,11 +31,40 @@
 #include <QStyleFactory>
 #include <QtGlobal>
 
+#if defined(Q_OS_WIN32)
+#include <cstdio>
+#include <io.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+// In a GUI-subsystem (WIN32_EXECUTABLE) build the process starts without a console and
+// the CRT leaves the standard streams without valid file descriptors.  That silently
+// discards all LAMMPS output before the dup2()-based capture in StdCapture can grab it.
+// If launched from a terminal, attach to that console; otherwise rebind the streams to
+// the NUL device so they get valid descriptors.  Streams whose descriptor is already
+// valid (e.g. redirected to a file by the parent process) are left untouched.
+static void initConsoleIO()
+{
+    bool has_console = AttachConsole(ATTACH_PARENT_PROCESS);
+    auto fd_invalid  = [](FILE *fp) {
+        int fd = _fileno(fp);
+        return (fd < 0) || (_get_osfhandle(fd) < 0);
+    };
+    if (fd_invalid(stdin)) freopen(has_console ? "CONIN$" : "NUL:", "r", stdin);
+    if (fd_invalid(stdout)) freopen(has_console ? "CONOUT$" : "NUL:", "w", stdout);
+    if (fd_invalid(stderr)) freopen(has_console ? "CONOUT$" : "NUL:", "w", stderr);
+}
+#else
+// nothing to do
+static void initConsoleIO() {}
+#endif
+
 #define stringify(x) myxstr(x)
 #define myxstr(x) #x
 
 int main(int argc, char *argv[])
 {
+    initConsoleIO();
 #if defined(Q_OS_MACOS)
     // macOS does not support the "C" locale with UTF-8 encoding,
     // Since Qt requires UTF-8 we use "en_US" instead.


### PR DESCRIPTION
**Summary**

This configures LAMMPS-GUI to be a pure GUI app and thus it won't automatically launch a console terminal anymore. Also all executables and shared libraries are cryptographically signed (with a self-signed certificate) and some metadata added to the executable.
The signing process is orchestrated in such a way that a proper authorized signing
certificate can be substituted easily.

**Author(s)**

Axel Kohlmeyer, Temple U

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS-GUI and redistributed under the GNU General Public License version 2 or later (GPL v2+).

**Implementation Notes**

Some workaround had to be implemented to re-attach file descriptors 0, 1, 2 so they can be captured to collect console output, e.g. for the log window or the about dialog and other steps where the output from the info command is parsed and processed.

The documentation now explains how to download and import the custom root certificate.

**Post Submission Checklist**

- [x] The feature or features in this pull request is complete
- [x] Licensing information is complete
- [x] Corresponding author information is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included

